### PR TITLE
Add forward compatibility for Storybook 4

### DIFF
--- a/src/server/getStorybook.js
+++ b/src/server/getStorybook.js
@@ -5,5 +5,5 @@ export default async (browser, iframeUrl) => {
     waitUntil: "networkidle2"
   });
 
-  return page.evaluate("preview.getStorybook()");
+  return page.evaluate("(typeof preview !== 'undefined') ? preview.getStorybook() : __STORYBOOK_CLIENT_API__.getStorybook()");
 };


### PR DESCRIPTION
This commit ensures either the `preview` object or the `__STORYBOOK_CLIENT_API__` object is used to access the Storybook client API.