### PR TITLE
preview typeof object

### DIFF
--- a/src/server/getStorybook.js
+++ b/src/server/getStorybook.js
@@ -5,5 +5,5 @@ export default async (browser, iframeUrl) => {
     waitUntil: "networkidle2"
   });
 
-  return page.evaluate("(typeof preview !== 'undefined') ? preview.getStorybook() : __STORYBOOK_CLIENT_API__.getStorybook()");
+  return page.evaluate("(typeof preview === 'object' && typeof preview.getStorybook !== 'undefined') ? preview.getStorybook() : __STORYBOOK_CLIENT_API__.getStorybook()");
 };


### PR DESCRIPTION
Currently using `4.0.0-alpha.16`

I get an issue that `typeof preview` is `number`, which means it tries to get  `preview.getStorybook()` which for mean in storybook 4 doesn't exist.

This PR fixes the issue of it picking `__STORYBOOK_CLIENT_API__.getStorybook()` for me, for version 4.

However is there need for some more exploration as to why it comes up as a number?
