### PR TITLE
handle replacing multiple spaces and slashes within a story name

### DIFF
--- a/src/server/Story2sketch.js
+++ b/src/server/Story2sketch.js
@@ -345,8 +345,8 @@ export default class Story2sketch {
         layers: this.positionSymbols(this.symbolsByGrouping[grouping])
       };
       const filename = `${grouping
-        .replace(" ", "_")
-        .replace("/", "+")}.asketch.json`;
+        .replace(/ /g, "_")
+        .replace(/\//g, "+")}.asketch.json`;
 
       const outputPath = path.join(this.output, filename);
 


### PR DESCRIPTION
Previously it was only replacing 1 of each of these characters and I would get an error like:


```sh
(node:87641) UnhandledPromiseRejectionWarning: Error: ENOENT: no such file or directory, open '/Users/alisowski/Documents/web-components/out/sketch/Components|Deck+Carrousel/Header.asketch.json'
    at Object.fs.openSync (fs.js:646:18)
    at Object.fs.writeFileSync (fs.js:1299:33)
    at Story2sketch.writeByGrouping (/Users/alisowski/Documents/web-components/node_modules/story2sketch/lib/server/Story2sketch.js:838:24)
    at Story2sketch._callee6$ (/Users/alisowski/Documents/web-components/node_modules/story2sketch/lib/server/Story2sketch.js:886:24)
    at tryCatch (/Users/alisowski/Documents/web-components/node_modules/babel-runtime/node_modules/regenerator-runtime/runtime.js:62:40)
    at Generator.invoke [as _invoke] (/Users/alisowski/Documents/web-components/node_modules/babel-runtime/node_modules/regenerator-runtime/runtime.js:296:22)
    at Generator.prototype.(anonymous function) [as next] (/Users/alisowski/Documents/web-components/node_modules/babel-runtime/node_modules/regenerator-runtime/runtime.js:114:21)
    at step (/Users/alisowski/Documents/web-components/node_modules/babel-runtime/helpers/asyncToGenerator.js:17:30)
    at /Users/alisowski/Documents/web-components/node_modules/babel-runtime/helpers/asyncToGenerator.js:28:13
    at <anonymous>
```