### PR TITLE
Link to latest non-broken plugin and update html-sketchapp to 4.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Convert [Storybook](https://storybook.js.org) stories into [Sketch](https://www.
 
 ## Quickstart
 
-Firstly, get [Sketch](https://sketchapp.com) and [npm](https://nodejs.org/en/download/). Then install [`asketch2sketch.sketchplugin`](https://github.com/html-sketchapp/html-sketchapp/releases/download/v4.3.0/asketch2sketch-4-3-0.sketchplugin.zip) into Sketch:
+Firstly, get [Sketch](https://sketchapp.com) and [npm](https://nodejs.org/en/download/). Then install [`asketch2sketch.sketchplugin`](https://github.com/html-sketchapp/html-sketchapp/releases/download/v4.4.1/asketch2sketch-4-4-1.sketchplugin.zip) into Sketch:
 
 <img src="https://i.imgur.com/9eDm6NQ.png" width="450" alt="Installing Sketch plugin" title="Installing Sketch plugin" />
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     }
   },
   "dependencies": {
-    "@brainly/html-sketchapp": "^4.3.0",
+    "@brainly/html-sketchapp": "^4.4.1",
     "babel-runtime": "^6.26.0",
     "chalk": "^2.3.0",
     "cosmiconfig": "^4.0.0",


### PR DESCRIPTION
Per [this comment](https://github.com/chrisvxd/story2sketch/issues/60#issuecomment-719025482), the linked Almost Sketch to Sketch plugin from the README has a bug that prevents layer imports. The latest release of html-sketchapp (4.4.1) fixes this issue.

This updates the README link to the plugin and the html-sketchapp dependency to the latest.