### PR TITLE
fix/child-of-root: Changed firstChild to avoid empty text nodes

### DIFF
--- a/src/browser/page2layers.js
+++ b/src/browser/page2layers.js
@@ -95,7 +95,7 @@ export const getSymbol = ({
   let nodes;
 
   if (querySelector === "#root") {
-    nodes = document.querySelector(querySelector).firstChild;
+    nodes = document.querySelector(querySelector).firstElementChild;
   } else {
     nodes = document.querySelector(querySelector);
   }


### PR DESCRIPTION
Regarding #51, I changed the behavior of `getSymbol()` to only consider element nodes (not text ones).